### PR TITLE
fix entries for STARRED CLUES in Theme tab

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -143,10 +143,10 @@ function getCluesPreOrPostfixedWith(clues, token, entries, type) {
     for (let i in clues) {
       var clue_num = clues[i].number;
       var clue_text = clues[i].text;
-      var clue_entry = entries[clue_num];
+      var clue_entry = entries[Number(i)+1]; /* dictionary is 1-based */
       if (clue_text.startsWith(token) || clue_text.endsWith(token)) {
         retClues.push(clue_num + type + ' [' + clue_text + ']');
-        retEntries.push(entries[clue_num]);
+        retEntries.push(clue_entry);
       }
     }
 


### PR DESCRIPTION
was showing the wrong entries with (the correct—i.e., actually starred) starred clues

I think that this is a close-to-minimally-invasive fix, but I'm wondering if there's a better one—e.g., should the `entries` dictionary be 0-based (instead 1-based)? even bigger: should entries and/or clues be indexed instead by their actual numbers (e.g., if the second across entry is 5A TAPS, should it be indexed by 5 instead of 2 (or 1, if 0-based))? (I haven't looked much into the unraveling this might cause and/or if it's a good idea—and I suspect you've thought about it. (heck, I don't know enough about iterating over JavaScript dictionaries!)

(wasn't working with, e.g., [4/29/22 WSJ](http://herbach.dnsalias.com/wsj/wsj220429.puz))